### PR TITLE
Confirmation of a new variant of the bulb working with this repository.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,6 +21,8 @@ This a third-party home assistant custom components works for Cozylife Lights ba
 Tested it on [color bulbs (no homekit)](https://detail.1688.com/offer/617699711703.html?spm=a2615.2177701.autotrace-offerGeneral.1.12be5799WNMB96).
 It can be initialized though bluetooth. 
 
+It has also been tested on [color bulbs (with homekit)](https://www.aliexpress.com/item/4001365774507.html). It can run both Apple homekit and Home Assistant simultaneously.
+
 Switch and CW lights are not tested yet.
 CW lights should work.
 


### PR DESCRIPTION
Hello, 

I've bought [this bulb](https://www.aliexpress.com/item/4001365774507.html) from Aliexpress, It's possibly the same model, but with Apple HomeKit support, and it's branded as doHome.

I can confirm that with your repository I can manage this device on Home Assistant.

So this PR is just a note the Readme file for clarification.

Thanks for making this available!

Have a great day!