### PR TITLE
fix TypeError: 'NoneType' object is not iterable

### DIFF
--- a/custom_components/cozylife/switch.py
+++ b/custom_components/cozylife/switch.py
@@ -51,7 +51,7 @@ async def async_setup_platform(
 
 
     switches = []
-    for item in config.get('switches'):
+    for item in config.get('switches') or []:
         client = tcp_client(item.get('ip'))
         client._device_id = item.get('did')
         client._pid = item.get('pid')


### PR DESCRIPTION
config.get could return None

```
2023-11-29 13:05:20.210 ERROR (MainThread) [homeassistant.components.switch] Error while setting up cozylife platform for switch
Traceback (most recent call last):
  File "/lsiopy/lib/python3.11/site-packages/homeassistant/helpers/entity_platform.py", line 359, in _async_setup_platform
    await asyncio.shield(task)
  File "/config/custom_components/cozylife/switch.py", line 54, in async_setup_platform
    for item in config.get('switches'):
TypeError: 'NoneType' object is not iterable
```